### PR TITLE
Fix inch symbols in photogrammetry captions

### DIFF
--- a/photogrammetry.html
+++ b/photogrammetry.html
@@ -155,11 +155,11 @@
                 <img src="Gallery Shots/Radiant Overgrowth/Full.jpg"
                      alt="Radiant Overgrowth full model overview" />
                 <figcaption>
-                    Radiant Overgrowth, Unity3D, custom-built PC, flatscreen TV, 43.5×24.5”, 2024
+                    Radiant Overgrowth, Unity3D, custom-built PC, flatscreen TV, 43.5×24.5″, 2024
                 </figcaption>
                 <figcaption>
                     Radiant Overgrowth (print series), archival inkjet prints from simulation,
-                    10×10” each (framed), 2025
+                    10×10″ each (framed), 2025
                 </figcaption>
             </figure>
         </div>


### PR DESCRIPTION
## Summary
- replace curly double quotes around the dimensions in `photogrammetry.html` with the inch symbol

## Testing
- `grep -n "×" photogrammetry.html`


------
https://chatgpt.com/codex/tasks/task_e_684f2a4579108321b46f1c592e1dee48